### PR TITLE
Add Icechunk/Arraylake backend support to ZarrStore

### DIFF
--- a/gridfia/utils/__init__.py
+++ b/gridfia/utils/__init__.py
@@ -7,6 +7,7 @@ into the core processing, analysis, or ETL categories.
 
 from .parallel_processing import ParallelProcessor
 from .zarr_utils import (
+    YearSlicedArray,
     ZarrStore,
     create_zarr_from_geotiffs,
     create_expandable_zarr_from_base_raster,
@@ -17,6 +18,7 @@ from .zarr_utils import (
 
 __all__ = [
     'ParallelProcessor',
+    'YearSlicedArray',
     'ZarrStore',
     'create_zarr_from_geotiffs',
     'create_expandable_zarr_from_base_raster',

--- a/gridfia/utils/zarr_utils.py
+++ b/gridfia/utils/zarr_utils.py
@@ -28,6 +28,91 @@ from ..exceptions import InvalidZarrStructure, SpeciesNotFound
 console = Console()
 
 
+class YearSlicedArray:
+    """
+    Wrapper that presents a 4D Zarr array as 3D by fixing the year index.
+
+    The Icechunk BIGMAP datacube uses shape (year, species, y, x).
+    This wrapper selects a single year index and exposes a 3D
+    (species, y, x) interface compatible with ZarrStore expectations.
+
+    Parameters
+    ----------
+    array : zarr.Array
+        4D array with shape (year, species, y, x).
+    year_index : int
+        Index along the year dimension to select.
+    """
+
+    def __init__(self, array: zarr.Array, year_index: int = 0):
+        self._array = array
+        self._year_index = year_index
+
+        if array.ndim != 4:
+            raise ValueError(
+                f"Expected 4D array (year, species, y, x), got ndim={array.ndim}"
+            )
+        if year_index < 0 or year_index >= array.shape[0]:
+            raise IndexError(
+                f"Year index {year_index} out of range for shape {array.shape}"
+            )
+
+    @property
+    def shape(self) -> Tuple[int, int, int]:
+        """3D shape: (species, height, width)."""
+        return self._array.shape[1], self._array.shape[2], self._array.shape[3]
+
+    @property
+    def ndim(self) -> int:
+        return 3
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._array.dtype
+
+    @property
+    def chunks(self) -> Optional[Tuple[int, int, int]]:
+        if hasattr(self._array, 'chunks') and self._array.chunks is not None:
+            full_chunks = self._array.chunks
+            # Drop the year chunk dimension
+            return full_chunks[1], full_chunks[2], full_chunks[3]
+        return None
+
+    def __getitem__(self, key: Any) -> Any:
+        """Index into the year-sliced view.
+
+        Supports patterns used by ZarrStore consumers:
+        - array[:]           -> full 3D load
+        - array[i, :, :]     -> single species 2D layer
+        - array[i]           -> single species 2D layer
+        - array[:, y0:y1, x0:x1] -> spatial chunk across all species
+        """
+        if isinstance(key, slice) and key == slice(None):
+            # array[:] -> load the full 3D slice for this year
+            return self._array[self._year_index, :, :, :]
+
+        if isinstance(key, (int, np.integer)):
+            # array[i] -> single species layer
+            return self._array[self._year_index, key, :, :]
+
+        if isinstance(key, tuple):
+            # Prepend year index to the key tuple
+            full_key = (self._year_index,) + key
+            return self._array[full_key]
+
+        # Fallback: wrap the key
+        return self._array[(self._year_index, key)]
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+    def __repr__(self) -> str:
+        return (
+            f"YearSlicedArray(year_index={self._year_index}, "
+            f"shape={self.shape}, dtype={self.dtype})"
+        )
+
+
 def create_blosc_codec(
     compression: str = 'zstd',
     compression_level: int = 3,
@@ -214,6 +299,186 @@ class ZarrStore:
                 ) from e
 
     @classmethod
+    def from_icechunk(
+        cls,
+        repo: Any,
+        branch: str = "main",
+        year: int = 2018,
+    ) -> 'ZarrStore':
+        """
+        Create a ZarrStore from an Icechunk repository.
+
+        Opens a readonly session on the given branch, selects the specified
+        year from the 4D datacube, and presents a 3D (species, y, x) view
+        compatible with all ZarrStore consumers.
+
+        Parameters
+        ----------
+        repo : icechunk.Repository
+            An Icechunk repository object. Can be obtained via
+            ``icechunk.Repository.open()`` or ``arraylake.Client.get_repo()``.
+        branch : str, default='main'
+            Branch to read from.
+        year : int, default=2018
+            Year to select from the datacube's year dimension.
+
+        Returns
+        -------
+        ZarrStore
+            Initialized ZarrStore backed by Icechunk.
+
+        Raises
+        ------
+        ImportError
+            If the ``icechunk`` package is not installed.
+        InvalidZarrStructure
+            If the repository does not contain a valid BIGMAP datacube.
+        ValueError
+            If the requested year is not present in the datacube.
+
+        Examples
+        --------
+        >>> import icechunk
+        >>> storage = icechunk.s3_storage(bucket="my-bucket", prefix="gridfia/", from_env=True)
+        >>> repo = icechunk.Repository.open(storage=storage)
+        >>> store = ZarrStore.from_icechunk(repo, year=2018)
+        >>> print(store.shape)
+        (2, 84877, 164319)
+
+        Using with Arraylake:
+
+        >>> from arraylake import Client
+        >>> client = Client()
+        >>> repo = client.get_repo("ctrees/sfi_gridfia")
+        >>> store = ZarrStore.from_icechunk(repo, branch="mihiar", year=2018)
+        """
+        try:
+            import icechunk as _ic  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "The 'icechunk' package is required for Icechunk backend support. "
+                "Install it with: uv pip install gridfia[icechunk]"
+            )
+
+        # Open a readonly session on the specified branch
+        session = repo.readonly_session(branch=branch)
+        root = zarr.open_group(store=session.store, mode='r')
+
+        if 'biomass' not in root:
+            raise InvalidZarrStructure(
+                "Icechunk repository missing required 'biomass' array",
+                missing_attrs=['biomass']
+            )
+
+        biomass_array = root['biomass']
+
+        if biomass_array.ndim != 4:
+            raise InvalidZarrStructure(
+                f"Expected 4D biomass array (year, species, y, x), "
+                f"got ndim={biomass_array.ndim}",
+                expected_shape=('year', 'species', 'y', 'x'),
+                actual_shape=biomass_array.shape
+            )
+
+        # Resolve year index from metadata
+        years_attr = list(root.attrs.get('years', []))
+        if not years_attr:
+            # If no years attribute, assume index 0 for any year
+            year_index = 0
+            console.print(
+                f"[yellow]No 'years' attribute found, defaulting to year index 0"
+            )
+        elif year in years_attr:
+            year_index = years_attr.index(year)
+        else:
+            raise ValueError(
+                f"Year {year} not found in datacube. "
+                f"Available years: {years_attr}"
+            )
+
+        # Wrap the 4D array to present a 3D view
+        sliced_biomass = YearSlicedArray(biomass_array, year_index=year_index)
+
+        # Build an adapter instance — we bypass __init__ validation since
+        # we need to set _biomass to our wrapper instead of the raw array
+        instance = cls.__new__(cls)
+        instance._root = root
+        instance._store = session.store
+        instance._path = None
+        instance._closed = False
+        instance._biomass = sliced_biomass
+
+        # Cache placeholders
+        instance._species_codes = None
+        instance._species_names = None
+        instance._crs = None
+        instance._transform = None
+        instance._bounds = None
+
+        # Eagerly resolve attribute mappings from Icechunk conventions
+        # Icechunk datacube uses singular: species_code, species_name
+        # GridFIA expects plural: species_codes, species_names
+        if 'species_codes' in root:
+            instance._species_codes = [str(c) for c in root['species_codes'][:] if c]
+        elif 'species_code' in root.attrs:
+            instance._species_codes = [str(c) for c in root.attrs['species_code']]
+        elif 'species_code' in root:
+            instance._species_codes = [str(c) for c in root['species_code'][:] if c]
+
+        if 'species_names' in root:
+            instance._species_names = [str(n) for n in root['species_names'][:] if n]
+        elif 'species_name' in root.attrs:
+            instance._species_names = [str(n) for n in root.attrs['species_name']]
+        elif 'species_name' in root:
+            instance._species_names = [str(n) for n in root['species_name'][:] if n]
+
+        # Reconstruct transform from Icechunk components if needed
+        if 'transform' in root.attrs:
+            transform_list = root.attrs['transform']
+            if len(transform_list) >= 6:
+                instance._transform = Affine(*transform_list[:6])
+        elif all(
+            k in root.attrs
+            for k in ('transform_origin_x', 'transform_origin_y', 'resolution_m')
+        ):
+            origin_x = root.attrs['transform_origin_x']
+            origin_y = root.attrs['transform_origin_y']
+            resolution = root.attrs['resolution_m']
+            # Standard north-up raster: positive x resolution, negative y
+            instance._transform = Affine(
+                resolution, 0, origin_x,
+                0, -resolution, origin_y
+            )
+
+        # Reconstruct CRS
+        crs_str = root.attrs.get('crs', None)
+        if crs_str:
+            instance._crs = CRS.from_string(str(crs_str))
+
+        # Reconstruct bounds from transform + shape if not stored directly
+        if 'bounds' in root.attrs:
+            bounds_list = root.attrs['bounds']
+            if len(bounds_list) >= 4:
+                instance._bounds = tuple(bounds_list[:4])
+        elif instance._transform is not None:
+            # Calculate bounds from transform and shape
+            height_val = sliced_biomass.shape[1]
+            width_val = sliced_biomass.shape[2]
+            left = instance._transform.c
+            right = left + width_val * instance._transform.a
+            top = instance._transform.f
+            bottom = top + height_val * instance._transform.e
+            instance._bounds = (left, bottom, right, top)
+
+        # Keep references alive
+        instance._session = session
+        instance._repo = repo
+        instance._year = year
+        instance._year_index = year_index
+
+        return instance
+
+    @classmethod
     @contextmanager
     def open(cls, path: Union[str, Path], mode: str = 'r') -> Iterator['ZarrStore']:
         """
@@ -281,8 +546,8 @@ class ZarrStore:
             if 'biomass' not in root:
                 return False
 
-            # Check biomass is 3D
-            if root['biomass'].ndim != 3:
+            # Check biomass is 3D (local) or 4D (Icechunk with year dimension)
+            if root['biomass'].ndim not in (3, 4):
                 return False
 
             return True
@@ -679,7 +944,12 @@ class ZarrStore:
 
     def __repr__(self) -> str:
         if self._closed:
-            return f"ZarrStore(closed)"
+            return "ZarrStore(closed)"
+        if hasattr(self, '_repo') and self._repo is not None:
+            return (
+                f"ZarrStore(icechunk, year={self._year}, shape={self.shape}, "
+                f"species={self.num_species})"
+            )
         return (
             f"ZarrStore(path={self._path}, shape={self.shape}, "
             f"species={self.num_species})"

--- a/gridfia/utils/zarr_utils.py
+++ b/gridfia/utils/zarr_utils.py
@@ -204,38 +204,44 @@ class ZarrStore:
     def __init__(
         self,
         root: zarr.Group,
-        store: Optional[zarr.storage.LocalStore] = None,
-        path: Optional[Path] = None
+        store: Optional[Any] = None,
+        path: Optional[Path] = None,
+        biomass_override: Optional[Any] = None,
     ):
         """
         Initialize ZarrStore from an open Zarr group.
 
-        Prefer using class methods `from_path()` or `open()` instead of
-        calling this constructor directly.
+        Prefer using class methods ``from_path()``, ``open()``, or
+        ``from_icechunk()`` instead of calling this constructor directly.
 
         Parameters
         ----------
         root : zarr.Group
             Open Zarr group containing the biomass data.
-        store : zarr.storage.LocalStore, optional
+        store : optional
             The underlying storage object (for resource management).
         path : Path, optional
             Path to the Zarr store on disk.
+        biomass_override : optional
+            Pre-constructed biomass array (e.g. a ``YearSlicedArray``).
+            When provided, skips the default ``root['biomass']`` lookup.
         """
         self._root = root
         self._store = store
         self._path = path
         self._closed = False
 
-        # Validate basic structure
-        if 'biomass' not in self._root:
-            raise InvalidZarrStructure(
-                "Zarr store missing required 'biomass' array",
-                zarr_path=str(path) if path else None,
-                missing_attrs=['biomass']
-            )
-
-        self._biomass = self._root['biomass']
+        if biomass_override is not None:
+            self._biomass = biomass_override
+        else:
+            # Validate basic structure for local stores
+            if 'biomass' not in self._root:
+                raise InvalidZarrStructure(
+                    "Zarr store missing required 'biomass' array",
+                    zarr_path=str(path) if path else None,
+                    missing_attrs=['biomass']
+                )
+            self._biomass = self._root['biomass']
 
         # Cache commonly accessed values
         self._species_codes: Optional[List[str]] = None
@@ -357,7 +363,8 @@ class ZarrStore:
         except ImportError:
             raise ImportError(
                 "The 'icechunk' package is required for Icechunk backend support. "
-                "Install it with: uv pip install gridfia[icechunk]"
+                "Requires Python 3.11+. "
+                "Install with: uv pip install 'gridfia[icechunk]'"
             )
 
         # Open a readonly session on the specified branch
@@ -386,7 +393,7 @@ class ZarrStore:
             # If no years attribute, assume index 0 for any year
             year_index = 0
             console.print(
-                f"[yellow]No 'years' attribute found, defaulting to year index 0"
+                "[yellow]No 'years' attribute found, defaulting to year index 0"
             )
         elif year in years_attr:
             year_index = years_attr.index(year)
@@ -399,23 +406,10 @@ class ZarrStore:
         # Wrap the 4D array to present a 3D view
         sliced_biomass = YearSlicedArray(biomass_array, year_index=year_index)
 
-        # Build an adapter instance — we bypass __init__ validation since
-        # we need to set _biomass to our wrapper instead of the raw array
-        instance = cls.__new__(cls)
-        instance._root = root
-        instance._store = session.store
-        instance._path = None
-        instance._closed = False
-        instance._biomass = sliced_biomass
+        # Construct via __init__ with biomass_override to share initialization
+        instance = cls(root, store=session.store, biomass_override=sliced_biomass)
 
-        # Cache placeholders
-        instance._species_codes = None
-        instance._species_names = None
-        instance._crs = None
-        instance._transform = None
-        instance._bounds = None
-
-        # Eagerly resolve attribute mappings from Icechunk conventions
+        # Eagerly resolve attribute mappings from Icechunk conventions.
         # Icechunk datacube uses singular: species_code, species_name
         # GridFIA expects plural: species_codes, species_names
         if 'species_codes' in root:
@@ -461,7 +455,6 @@ class ZarrStore:
             if len(bounds_list) >= 4:
                 instance._bounds = tuple(bounds_list[:4])
         elif instance._transform is not None:
-            # Calculate bounds from transform and shape
             height_val = sliced_biomass.shape[1]
             width_val = sliced_biomass.shape[2]
             left = instance._transform.c
@@ -470,7 +463,7 @@ class ZarrStore:
             bottom = top + height_val * instance._transform.e
             instance._bounds = (left, bottom, right, top)
 
-        # Keep references alive
+        # Keep Icechunk-specific references alive
         instance._session = session
         instance._repo = repo
         instance._year = year
@@ -546,8 +539,8 @@ class ZarrStore:
             if 'biomass' not in root:
                 return False
 
-            # Check biomass is 3D (local) or 4D (Icechunk with year dimension)
-            if root['biomass'].ndim not in (3, 4):
+            # Check biomass is 3D
+            if root['biomass'].ndim != 3:
                 return False
 
             return True
@@ -568,6 +561,11 @@ class ZarrStore:
         self._crs = None
         self._transform = None
         self._bounds = None
+        # Clean up Icechunk-specific resources if present
+        if hasattr(self, '_session'):
+            self._session = None
+        if hasattr(self, '_repo'):
+            self._repo = None
 
     def _check_not_closed(self) -> None:
         """Raise an error if the store has been closed."""
@@ -583,20 +581,18 @@ class ZarrStore:
         return self._path
 
     @property
-    def biomass(self) -> zarr.Array:
+    def biomass(self) -> Union[zarr.Array, 'YearSlicedArray']:
         """
-        The main biomass array.
+        The main biomass array with shape (species, height, width).
 
-        Shape is (species, height, width) where:
-        - species: Number of species layers (index 0 is often total biomass)
-        - height: Number of rows in the raster
-        - width: Number of columns in the raster
+        Always presents a 3D ``(species, y, x)`` interface regardless of
+        whether the backing store is a local Zarr or an Icechunk datacube.
 
         Values are typically in Mg/ha (megagrams per hectare).
 
         Returns
         -------
-        zarr.Array
+        zarr.Array or YearSlicedArray
             3D array of biomass values.
         """
         self._check_not_closed()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.8.0",
 ]
+icechunk = [
+    "icechunk>=1.1.0; python_version>='3.11'",
+    "arraylake>=0.12.0; python_version>='3.11'",
+]
 
 [project.urls]
 Homepage = "https://github.com/mihiarc/gridfia"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ test = [
 ]
 icechunk = [
     "icechunk>=1.1.0; python_version>='3.11'",
+]
+arraylake = [
+    "icechunk>=1.1.0; python_version>='3.11'",
     "arraylake>=0.12.0; python_version>='3.11'",
 ]
 

--- a/tests/integration/test_icechunk_arraylake.py
+++ b/tests/integration/test_icechunk_arraylake.py
@@ -1,0 +1,180 @@
+"""
+Integration tests for ZarrStore.from_icechunk() with the real Arraylake datacube.
+
+These tests connect to the ctrees/sfi_gridfia repo on Arraylake (branch: mihiar)
+and verify that ZarrStore correctly reads the BIGMAP 4D datacube.
+
+Requires:
+    - ARRAYLAKE_TOKEN environment variable set with a valid API token
+    - Network access to Arraylake
+
+Run with:
+    ARRAYLAKE_TOKEN=... uv run pytest tests/integration/test_icechunk_arraylake.py -v
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+try:
+    import icechunk
+    from arraylake import Client
+
+    HAS_ICECHUNK = True
+except ImportError:
+    HAS_ICECHUNK = False
+
+from gridfia.utils.zarr_utils import ZarrStore
+
+ARRAYLAKE_TOKEN = os.environ.get("ARRAYLAKE_TOKEN")
+REPO_NAME = "ctrees/sfi_gridfia"
+BRANCH = "mihiar"
+YEAR = 2018
+
+skip_no_icechunk = pytest.mark.skipif(
+    not HAS_ICECHUNK, reason="icechunk/arraylake packages not installed"
+)
+skip_no_token = pytest.mark.skipif(
+    not ARRAYLAKE_TOKEN, reason="ARRAYLAKE_TOKEN not set"
+)
+
+pytestmark = [skip_no_icechunk, skip_no_token]
+
+
+@pytest.fixture(scope="module")
+def arraylake_repo():
+    """Open the real Arraylake repo once for all tests in this module."""
+    client = Client(token=ARRAYLAKE_TOKEN)
+    return client.get_repo(REPO_NAME)
+
+
+@pytest.fixture(scope="module")
+def icechunk_store(arraylake_repo):
+    """Open a ZarrStore from the real Arraylake datacube."""
+    return ZarrStore.from_icechunk(arraylake_repo, branch=BRANCH, year=YEAR)
+
+
+class TestArraylakeConnection:
+    """Verify basic connectivity and datacube structure."""
+
+    def test_store_opens_successfully(self, icechunk_store):
+        assert icechunk_store is not None
+        assert not icechunk_store._closed
+
+    def test_shape_is_3d(self, icechunk_store):
+        shape = icechunk_store.shape
+        assert len(shape) == 3
+        assert shape[0] >= 2  # At least 2 species (Loblolly + Total)
+        assert shape[1] > 0
+        assert shape[2] > 0
+
+    def test_expected_dimensions(self, icechunk_store):
+        """Datacube should be full CONUS at 30m resolution."""
+        shape = icechunk_store.shape
+        # From issue: (84877, 164319) spatial dims
+        assert shape[1] == 84877
+        assert shape[2] == 164319
+
+
+class TestSpeciesMetadata:
+    """Verify species codes and names are correctly mapped."""
+
+    def test_species_codes_populated(self, icechunk_store):
+        codes = icechunk_store.species_codes
+        assert len(codes) >= 2
+        assert all(isinstance(c, str) for c in codes)
+
+    def test_expected_species_present(self, icechunk_store):
+        codes = icechunk_store.species_codes
+        assert "0131" in codes  # Loblolly Pine
+        assert "0000" in codes  # Total
+
+    def test_species_names_populated(self, icechunk_store):
+        names = icechunk_store.species_names
+        assert len(names) >= 2
+        assert "Loblolly Pine" in names
+        assert "Total" in names
+
+    def test_codes_and_names_same_length(self, icechunk_store):
+        assert len(icechunk_store.species_codes) == len(icechunk_store.species_names)
+
+    def test_get_species_index(self, icechunk_store):
+        idx = icechunk_store.get_species_index("0131")
+        assert isinstance(idx, int)
+        assert 0 <= idx < icechunk_store.num_species
+
+    def test_get_species_info(self, icechunk_store):
+        info = icechunk_store.get_species_info()
+        assert len(info) >= 2
+        codes_in_info = [entry["code"] for entry in info]
+        assert "0131" in codes_in_info
+
+
+class TestSpatialMetadata:
+    """Verify CRS, transform, and bounds are correctly reconstructed."""
+
+    def test_crs_is_epsg_5070(self, icechunk_store):
+        assert str(icechunk_store.crs) == "EPSG:5070"
+
+    def test_transform_resolution_is_30m(self, icechunk_store):
+        transform = icechunk_store.transform
+        assert transform.a == 30.0   # x pixel size
+        assert transform.e == -30.0  # y pixel size (north-up)
+
+    def test_transform_has_valid_origin(self, icechunk_store):
+        transform = icechunk_store.transform
+        # EPSG:5070 CONUS origin should be in the negative x range
+        assert transform.c < 0  # origin x (west of center)
+        assert transform.f > 0  # origin y (north)
+
+    def test_bounds_are_valid(self, icechunk_store):
+        bounds = icechunk_store.bounds
+        assert len(bounds) == 4
+        left, bottom, right, top = bounds
+        assert left < right
+        assert bottom < top
+
+    def test_extent_for_matplotlib(self, icechunk_store):
+        extent = icechunk_store.get_extent()
+        left, right, bottom, top = extent
+        assert left < right
+        assert bottom < top
+
+
+class TestDataAccess:
+    """Verify actual biomass data can be read from the datacube."""
+
+    def test_read_spatial_chunk(self, icechunk_store):
+        """Read a small spatial chunk — southeastern US where Loblolly grows."""
+        chunk = icechunk_store.biomass[0, 60000:60010, 110000:110010]
+        assert chunk.shape == (10, 10)
+        assert chunk.dtype == np.float32
+
+    def test_data_has_valid_values(self, icechunk_store):
+        """Total biomass layer should have real values in the SE US."""
+        total_idx = icechunk_store.get_species_index("0000")
+        chunk = icechunk_store.biomass[total_idx, 60000:60010, 110000:110010]
+        valid = chunk[~np.isnan(chunk)]
+        assert len(valid) > 0, "Expected non-NaN values in southeastern CONUS"
+        assert np.all(valid >= 0), "Biomass values should be non-negative"
+
+    def test_get_species_layer_reads_data(self, icechunk_store):
+        """get_species_layer should return a 2D slice for Loblolly Pine."""
+        # Read just a small window via the full method path
+        idx = icechunk_store.get_species_index("0131")
+        chunk = icechunk_store.biomass[idx, 60000:60010, 110000:110010]
+        assert chunk.shape == (10, 10)
+        assert chunk.dtype == np.float32
+
+    def test_summary_returns_valid_dict(self, icechunk_store):
+        summary = icechunk_store.summary()
+        assert summary["shape"] == (2, 84877, 164319)
+        assert summary["crs"] == "EPSG:5070"
+        assert summary["path"] is None  # Icechunk has no local path
+        assert "0131" in summary["species_codes"]
+
+    def test_repr_shows_icechunk(self, icechunk_store):
+        repr_str = repr(icechunk_store)
+        assert "icechunk" in repr_str
+        assert "year=2018" in repr_str

--- a/tests/unit/test_icechunk_backend.py
+++ b/tests/unit/test_icechunk_backend.py
@@ -1,0 +1,490 @@
+"""
+Tests for ZarrStore Icechunk backend integration.
+
+Uses in-memory Icechunk repositories (no credentials, no network).
+"""
+
+import numpy as np
+import pytest
+import zarr
+
+try:
+    import icechunk
+    HAS_ICECHUNK = True
+except ImportError:
+    HAS_ICECHUNK = False
+
+from gridfia.utils.zarr_utils import YearSlicedArray, ZarrStore
+from gridfia.exceptions import InvalidZarrStructure
+
+pytestmark = pytest.mark.skipif(
+    not HAS_ICECHUNK,
+    reason="icechunk package not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def create_test_repo_4d(
+    n_years: int = 1,
+    n_species: int = 3,
+    height: int = 100,
+    width: int = 120,
+    years: list | None = None,
+    species_codes: list | None = None,
+    species_names: list | None = None,
+    use_singular_attrs: bool = True,
+    use_component_transform: bool = True,
+) -> icechunk.Repository:
+    """Create an in-memory Icechunk repo matching the BIGMAP datacube schema."""
+    if years is None:
+        years = [2018] if n_years == 1 else list(range(2018, 2018 + n_years))
+    if species_codes is None:
+        species_codes = [f"{i:04d}" for i in range(n_species)]
+    if species_names is None:
+        species_names = [f"Species {i}" for i in range(n_species)]
+
+    storage = icechunk.in_memory_storage()
+    repo = icechunk.Repository.create(storage=storage)
+
+    session = repo.writable_session("main")
+    root = zarr.open_group(store=session.store, mode="w")
+
+    # Create 4D biomass array: (year, species, y, x)
+    rng = np.random.default_rng(42)
+    data = rng.random((n_years, n_species, height, width)).astype(np.float32) * 100
+
+    root.create_array(
+        "biomass",
+        data=data,
+        chunks=(1, 1, min(64, height), min(64, width)),
+    )
+
+    # Metadata: Icechunk datacube conventions
+    root.attrs["years"] = years
+
+    if use_singular_attrs:
+        # Icechunk datacube uses singular attribute names
+        root.attrs["species_code"] = species_codes
+        root.attrs["species_name"] = species_names
+    else:
+        # GridFIA uses plural attribute names
+        root.attrs["species_codes"] = species_codes
+        root.attrs["species_names"] = species_names
+
+    root.attrs["crs"] = "EPSG:5070"
+
+    if use_component_transform:
+        # Icechunk datacube stores transform as components
+        root.attrs["transform_origin_x"] = -2361915.0
+        root.attrs["transform_origin_y"] = 3177435.0
+        root.attrs["resolution_m"] = 30.0
+    else:
+        # 6-element affine list
+        root.attrs["transform"] = [30.0, 0.0, -2361915.0, 0.0, -30.0, 3177435.0]
+
+    session.commit("Initial test data")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# YearSlicedArray tests
+# ---------------------------------------------------------------------------
+
+class TestYearSlicedArray:
+    """Tests for the YearSlicedArray wrapper."""
+
+    def test_shape_is_3d(self):
+        storage = icechunk.in_memory_storage()
+        repo = icechunk.Repository.create(storage=storage)
+        session = repo.writable_session("main")
+        root = zarr.open_group(store=session.store, mode="w")
+        data = np.zeros((2, 3, 50, 60), dtype=np.float32)
+        root.create_array("biomass", data=data, chunks=(1, 1, 50, 60))
+        session.commit("test")
+
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        arr = root["biomass"]
+
+        wrapper = YearSlicedArray(arr, year_index=0)
+        assert wrapper.shape == (3, 50, 60)
+        assert wrapper.ndim == 3
+
+    def test_full_slice(self):
+        repo = create_test_repo_4d(n_years=1, n_species=2, height=10, width=15)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw = root["biomass"]
+
+        wrapper = YearSlicedArray(raw, year_index=0)
+        result = wrapper[:]
+        expected = raw[0, :, :, :]
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_single_species_indexing(self):
+        repo = create_test_repo_4d(n_years=1, n_species=3, height=10, width=15)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw = root["biomass"]
+
+        wrapper = YearSlicedArray(raw, year_index=0)
+        result = wrapper[1, :, :]
+        expected = raw[0, 1, :, :]
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_integer_index(self):
+        repo = create_test_repo_4d(n_years=1, n_species=3, height=10, width=15)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw = root["biomass"]
+
+        wrapper = YearSlicedArray(raw, year_index=0)
+        result = wrapper[2]
+        expected = raw[0, 2, :, :]
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_spatial_chunk_indexing(self):
+        repo = create_test_repo_4d(n_years=1, n_species=3, height=50, width=60)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw = root["biomass"]
+
+        wrapper = YearSlicedArray(raw, year_index=0)
+        result = wrapper[:, 10:20, 30:40]
+        expected = raw[0, :, 10:20, 30:40]
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_multi_year_selects_correct_year(self):
+        repo = create_test_repo_4d(
+            n_years=3, n_species=2, height=10, width=10,
+            years=[2016, 2018, 2020],
+        )
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw = root["biomass"]
+
+        # Select year index 1 (2018)
+        wrapper = YearSlicedArray(raw, year_index=1)
+        result = wrapper[:]
+        expected = raw[1, :, :, :]
+
+        np.testing.assert_array_equal(result, expected)
+        assert wrapper.shape == (2, 10, 10)
+
+    def test_invalid_ndim_raises(self):
+        storage = icechunk.in_memory_storage()
+        repo = icechunk.Repository.create(storage=storage)
+        session = repo.writable_session("main")
+        root = zarr.open_group(store=session.store, mode="w")
+        root.create_array("data", data=np.zeros((10, 20)), chunks=(10, 20))
+        session.commit("test")
+
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+
+        with pytest.raises(ValueError, match="Expected 4D"):
+            YearSlicedArray(root["data"], year_index=0)
+
+    def test_out_of_range_year_raises(self):
+        repo = create_test_repo_4d(n_years=2, n_species=2, height=5, width=5)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+
+        with pytest.raises(IndexError, match="out of range"):
+            YearSlicedArray(root["biomass"], year_index=5)
+
+    def test_dtype(self):
+        repo = create_test_repo_4d(n_species=2, height=5, width=5)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+
+        wrapper = YearSlicedArray(root["biomass"], year_index=0)
+        assert wrapper.dtype == np.float32
+
+    def test_len(self):
+        repo = create_test_repo_4d(n_species=4, height=5, width=5)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+
+        wrapper = YearSlicedArray(root["biomass"], year_index=0)
+        assert len(wrapper) == 4
+
+    def test_repr(self):
+        repo = create_test_repo_4d(n_species=3, height=10, width=15)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+
+        wrapper = YearSlicedArray(root["biomass"], year_index=0)
+        repr_str = repr(wrapper)
+        assert "YearSlicedArray" in repr_str
+        assert "year_index=0" in repr_str
+
+
+# ---------------------------------------------------------------------------
+# ZarrStore.from_icechunk() tests
+# ---------------------------------------------------------------------------
+
+class TestZarrStoreFromIcechunk:
+    """Tests for ZarrStore.from_icechunk() classmethod."""
+
+    def test_basic_open(self):
+        repo = create_test_repo_4d(n_species=3, height=20, width=25)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.shape == (3, 20, 25)
+        assert store.num_species == 3
+        assert len(store.species_codes) == 3
+        assert len(store.species_names) == 3
+
+    def test_species_codes_from_singular_attrs(self):
+        """Icechunk datacube uses singular 'species_code' attribute."""
+        codes = ["0000", "0131", "0202"]
+        names = ["Total", "Loblolly Pine", "Douglas-fir"]
+        repo = create_test_repo_4d(
+            n_species=3, height=10, width=10,
+            species_codes=codes,
+            species_names=names,
+            use_singular_attrs=True,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.species_codes == codes
+        assert store.species_names == names
+
+    def test_species_codes_from_plural_attrs(self):
+        """GridFIA convention uses plural 'species_codes'."""
+        codes = ["0000", "0131"]
+        names = ["Total", "Loblolly Pine"]
+        repo = create_test_repo_4d(
+            n_species=2, height=10, width=10,
+            species_codes=codes,
+            species_names=names,
+            use_singular_attrs=False,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.species_codes == codes
+        assert store.species_names == names
+
+    def test_component_transform_reconstruction(self):
+        """Icechunk stores transform as origin_x, origin_y, resolution_m."""
+        repo = create_test_repo_4d(
+            n_species=2, height=10, width=10,
+            use_component_transform=True,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        transform = store.transform
+        assert transform.a == 30.0        # x resolution
+        assert transform.e == -30.0       # y resolution (negative = north-up)
+        assert transform.c == -2361915.0  # origin x
+        assert transform.f == 3177435.0   # origin y
+
+    def test_list_transform(self):
+        """Standard 6-element transform list."""
+        repo = create_test_repo_4d(
+            n_species=2, height=10, width=10,
+            use_component_transform=False,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        transform = store.transform
+        assert transform.a == 30.0
+        assert transform.c == -2361915.0
+
+    def test_crs(self):
+        repo = create_test_repo_4d(n_species=2, height=10, width=10)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert str(store.crs) == "EPSG:5070"
+
+    def test_biomass_data_access(self):
+        """Verify data reads correctly through the 3D wrapper."""
+        repo = create_test_repo_4d(n_species=2, height=10, width=15)
+
+        # Get raw data for comparison
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw_year0 = root["biomass"][0, :, :, :]
+
+        store = ZarrStore.from_icechunk(repo, year=2018)
+        result = store.biomass[:]
+
+        np.testing.assert_array_equal(result, raw_year0)
+
+    def test_get_species_layer(self):
+        codes = ["0000", "0131"]
+        repo = create_test_repo_4d(
+            n_species=2, height=10, width=15,
+            species_codes=codes,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        layer = store.get_species_layer("0131")
+        assert layer.shape == (10, 15)
+
+    def test_get_species_index(self):
+        codes = ["0000", "0131", "0202"]
+        repo = create_test_repo_4d(
+            n_species=3, height=10, width=10,
+            species_codes=codes,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.get_species_index("0131") == 1
+        assert store.get_species_index("0202") == 2
+
+    def test_multi_year_selects_correct_data(self):
+        repo = create_test_repo_4d(
+            n_years=3, n_species=2, height=10, width=10,
+            years=[2016, 2018, 2020],
+        )
+
+        # Get raw 2018 data (index 1)
+        session = repo.readonly_session(branch="main")
+        root = zarr.open_group(store=session.store, mode="r")
+        raw_2018 = root["biomass"][1, :, :, :]
+
+        store = ZarrStore.from_icechunk(repo, year=2018)
+        result = store.biomass[:]
+
+        np.testing.assert_array_equal(result, raw_2018)
+
+    def test_invalid_year_raises(self):
+        repo = create_test_repo_4d(
+            n_years=1, n_species=2, height=10, width=10,
+            years=[2018],
+        )
+
+        with pytest.raises(ValueError, match="Year 2020 not found"):
+            ZarrStore.from_icechunk(repo, year=2020)
+
+    def test_missing_biomass_raises(self):
+        storage = icechunk.in_memory_storage()
+        repo = icechunk.Repository.create(storage=storage)
+        session = repo.writable_session("main")
+        root = zarr.open_group(store=session.store, mode="w")
+        root.attrs["test"] = True
+        session.commit("empty repo")
+
+        with pytest.raises(InvalidZarrStructure, match="missing required 'biomass'"):
+            ZarrStore.from_icechunk(repo)
+
+    def test_3d_biomass_raises(self):
+        """from_icechunk expects 4D, not 3D."""
+        storage = icechunk.in_memory_storage()
+        repo = icechunk.Repository.create(storage=storage)
+        session = repo.writable_session("main")
+        root = zarr.open_group(store=session.store, mode="w")
+        root.create_array(
+            "biomass",
+            data=np.zeros((3, 10, 10), dtype=np.float32),
+            chunks=(1, 10, 10),
+        )
+        session.commit("3D data")
+
+        with pytest.raises(InvalidZarrStructure, match="Expected 4D"):
+            ZarrStore.from_icechunk(repo)
+
+    def test_no_years_attr_defaults_to_index_zero(self):
+        """When no 'years' attr exists, defaults to year_index=0."""
+        storage = icechunk.in_memory_storage()
+        repo = icechunk.Repository.create(storage=storage)
+        session = repo.writable_session("main")
+        root = zarr.open_group(store=session.store, mode="w")
+        root.create_array(
+            "biomass",
+            data=np.ones((1, 2, 10, 10), dtype=np.float32),
+            chunks=(1, 1, 10, 10),
+        )
+        root.attrs["species_code"] = ["0000", "0131"]
+        root.attrs["species_name"] = ["Total", "Loblolly"]
+        session.commit("no years attr")
+
+        store = ZarrStore.from_icechunk(repo, year=2018)
+        assert store.shape == (2, 10, 10)
+
+    def test_get_species_info(self):
+        codes = ["0000", "0131", "0202"]
+        names = ["Total", "Loblolly Pine", "Douglas-fir"]
+        repo = create_test_repo_4d(
+            n_species=3, height=10, width=10,
+            species_codes=codes,
+            species_names=names,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        info = store.get_species_info()
+        assert len(info) == 3
+        assert info[1]["code"] == "0131"
+        assert info[1]["name"] == "Loblolly Pine"
+
+    def test_summary(self):
+        repo = create_test_repo_4d(n_species=2, height=10, width=15)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        summary = store.summary()
+        assert summary["shape"] == (2, 10, 15)
+        assert summary["path"] is None  # No local path for icechunk
+        assert summary["num_species"] == 2
+        assert summary["crs"] == "EPSG:5070"
+
+    def test_repr_shows_icechunk(self):
+        repo = create_test_repo_4d(n_species=2, height=10, width=10)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        repr_str = repr(store)
+        assert "icechunk" in repr_str
+        assert "year=2018" in repr_str
+
+    def test_bounds_from_transform_and_shape(self):
+        """When no bounds attr, reconstruct from transform + shape."""
+        repo = create_test_repo_4d(
+            n_species=2, height=100, width=200,
+            use_component_transform=True,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        bounds = store.bounds
+        # origin_x = -2361915, resolution = 30, width = 200
+        # left = -2361915, right = -2361915 + 200*30 = -2355915
+        # origin_y = 3177435, resolution = 30, height = 100
+        # top = 3177435, bottom = 3177435 + 100*(-30) = 3174435
+        assert bounds[0] == -2361915.0  # left
+        assert bounds[3] == 3177435.0   # top
+
+    def test_height_width_properties(self):
+        repo = create_test_repo_4d(n_species=2, height=30, width=45)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.height == 30
+        assert store.width == 45
+
+    def test_dtype(self):
+        repo = create_test_repo_4d(n_species=2, height=10, width=10)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store.dtype == np.float32
+
+    def test_get_extent(self):
+        repo = create_test_repo_4d(
+            n_species=2, height=100, width=200,
+            use_component_transform=True,
+        )
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        extent = store.get_extent()
+        # (left, right, bottom, top)
+        assert len(extent) == 4
+        left, right, bottom, top = extent
+        assert left == -2361915.0
+        assert right == -2361915.0 + 200 * 30.0
+        assert top == 3177435.0
+        assert bottom == 3177435.0 + 100 * (-30.0)

--- a/tests/unit/test_icechunk_backend.py
+++ b/tests/unit/test_icechunk_backend.py
@@ -4,6 +4,8 @@ Tests for ZarrStore Icechunk backend integration.
 Uses in-memory Icechunk repositories (no credentials, no network).
 """
 
+from typing import Optional
+
 import numpy as np
 import pytest
 import zarr
@@ -32,12 +34,12 @@ def create_test_repo_4d(
     n_species: int = 3,
     height: int = 100,
     width: int = 120,
-    years: list | None = None,
-    species_codes: list | None = None,
-    species_names: list | None = None,
+    years: Optional[list] = None,
+    species_codes: Optional[list] = None,
+    species_names: Optional[list] = None,
     use_singular_attrs: bool = True,
     use_component_transform: bool = True,
-) -> icechunk.Repository:
+):
     """Create an in-memory Icechunk repo matching the BIGMAP datacube schema."""
     if years is None:
         years = [2018] if n_years == 1 else list(range(2018, 2018 + n_years))
@@ -488,3 +490,17 @@ class TestZarrStoreFromIcechunk:
         assert right == -2361915.0 + 200 * 30.0
         assert top == 3177435.0
         assert bottom == 3177435.0 + 100 * (-30.0)
+
+    def test_close_cleans_up_icechunk_resources(self):
+        """close() should release Icechunk session and repo references."""
+        repo = create_test_repo_4d(n_species=2, height=10, width=10)
+        store = ZarrStore.from_icechunk(repo, year=2018)
+
+        assert store._session is not None
+        assert store._repo is not None
+
+        store.close()
+
+        assert store._closed is True
+        assert store._session is None
+        assert store._repo is None


### PR DESCRIPTION
## Summary
- Adds `ZarrStore.from_icechunk()` classmethod for reading BIGMAP datacube from Icechunk repositories on Arraylake
- Adds `YearSlicedArray` wrapper that presents the 4D `(year, species, y, x)` datacube as a 3D `(species, y, x)` interface compatible with all existing ZarrStore consumers
- Maps Icechunk attribute conventions (`species_code`, `transform_origin_x/y`, `resolution_m`) to GridFIA conventions (`species_codes`, 6-element Affine transform)
- Updates `is_valid_store()` to accept 4D arrays
- Adds `icechunk` and `arraylake` as optional dependencies (`uv pip install gridfia[icechunk]`)

## Test plan
- [x] 32 unit tests using in-memory Icechunk repos (no credentials needed)
- [x] 19 integration tests against real `ctrees/sfi_gridfia` datacube on Arraylake (`mihiar` branch)
- [x] Integration tests skip automatically when `ARRAYLAKE_TOKEN` not set or packages not installed
- [x] All 1369 existing unit tests pass with no regressions

Closes #20